### PR TITLE
feat: some refactor and cleaning

### DIFF
--- a/components/SectionPartners.tsx
+++ b/components/SectionPartners.tsx
@@ -1,11 +1,10 @@
-import	React, {useEffect, useState}	from	'react';
-import router from 'next/router';
-import {usePartner} from 'contexts/usePartner';
+import React, {useEffect, useState} from 'react';
+import Link from 'next/link';
 import {PARTNERS} from 'utils/b2b/Partners';
-import	{motion}				from	'framer-motion';
+import {motion} from 'framer-motion';
 
 import type {ReactElement} from 'react';
-import	type {TFramerTransition, TPartnerList}		from	'types/types';
+import type {TFramerTransition, TPartnerList} from 'types/types';
 
 const variants = {
 	enter: (i: number): TFramerTransition => ({
@@ -21,7 +20,6 @@ const variants = {
 };
 
 function	Partners(): ReactElement {
-	const	{set_partner} = usePartner();
 	const	[partnerList, set_partnerList] = useState<TPartnerList[]>([]);
 
 	useEffect((): void => {
@@ -29,13 +27,6 @@ function	Partners(): ReactElement {
 		_partnerList.sort((): number => Math.random() - 0.5);
 		set_partnerList(_partnerList);
 	}, []);
-
-	async function navToDashboard(partner: string): Promise<void> {
-		if(set_partner){
-			set_partner(partner);
-			router.push('/dashboard');
-		}
-	}
 
 
 	return (
@@ -46,23 +37,22 @@ function	Partners(): ReactElement {
 				</div>
 				<div className={'mt-8 grid w-full max-w-5xl grid-cols-1 gap-8 md:grid-cols-3'}>
 					{partnerList?.map((partner: TPartnerList, i: number): ReactElement => (
-						<motion.div
-							key={partner.name}
-							custom={i % 3}
-							initial={'initial'}
-							whileInView={'enter'}
-							className={'flex h-66 cursor-pointer flex-col justify-between border-2 border-neutral-200 bg-neutral-200 p-6'}
-							variants={variants}
-							onClick={async (): Promise<void> => navToDashboard(partner.name)}	
-						>
-							<div className={'h-14'}>
-								{partner.logo}
-							</div>
-							<div className={'space-y-2'}>
-								<b className={'text-lg'}>{partner.name}</b>
-								<p>{partner.description}</p>
-							</div>
-						</motion.div>	
+						<Link key={partner.name} href={`/dashboard/${partner.shortName}`}>
+							<motion.div
+								custom={i % 3}
+								initial={'initial'}
+								whileInView={'enter'}
+								className={'flex h-66 cursor-pointer flex-col justify-between border-2 border-neutral-200 bg-neutral-200 p-6'}
+								variants={variants}>
+								<div className={'h-14'}>
+									{partner.logo}
+								</div>
+								<div className={'space-y-2'}>
+									<b className={'text-lg'}>{partner.name}</b>
+									<p>{partner.description}</p>
+								</div>
+							</motion.div>
+						</Link>
 					))}
 				</div>
 			</div>

--- a/components/SectionStats.tsx
+++ b/components/SectionStats.tsx
@@ -23,7 +23,7 @@ function	SectionStats(): ReactElement {
 		baseFetcher,
 		{revalidateOnFocus: false}
 	) as SWRResponse;
-	
+
 
 	return (
 		<section aria-label={'stats'} className={'mb-28 flex flex-row flex-wrap items-center md:mb-50'}>

--- a/components/SectionTargets.tsx
+++ b/components/SectionTargets.tsx
@@ -1,11 +1,11 @@
-import	React, {useEffect, useState}	from	'react';
-import	IconForDevelopers		from	'components/icons/IconForDevelopers';
-import	IconForInstitutions		from	'components/icons/IconForInstitutions';
-import	IconForProtocols		from	'components/icons/IconForProtocols';
-import	{motion}				from	'framer-motion';
+import React, {useEffect, useState} from 'react';
+import IconForDevelopers from 'components/icons/IconForDevelopers';
+import IconForInstitutions from 'components/icons/IconForInstitutions';
+import IconForProtocols from 'components/icons/IconForProtocols';
+import {motion} from 'framer-motion';
 
 import type {ReactElement} from 'react';
-import	type {TFramerTransition, TPartnerList}		from	'types/types';
+import type {TFramerTransition, TPartnerList} from 'types/types';
 
 const variants = {
 	enter: (i: number): TFramerTransition => ({
@@ -23,14 +23,17 @@ const variants = {
 const	targets: TPartnerList[] = [
 	{
 		name: 'For Protocols',
+		shortName: 'protocols',
 		description: 'Integration platform for  effortless yield optimization',
 		logo: <IconForProtocols className={'text-900'} />
 	}, {
 		name: 'For Developers',
+		shortName: 'developers',
 		description: 'Sandbox for novel and innovative DeFi applications',
 		logo: <IconForDevelopers className={'text-900'} />
 	}, {
 		name: 'For Organizations & Institutions',
+		shortName: 'institutions',
 		description: 'Infrastructure for accessing fixed yield in a compliant manner',
 		logo: <IconForInstitutions className={'text-900'} />
 	}
@@ -68,7 +71,7 @@ function	Targets(): ReactElement {
 								<b className={'text-lg'}>{target.name}</b>
 								<p>{target.description}</p>
 							</div>
-						</motion.div>	
+						</motion.div>
 					))}
 				</div>
 			</div>

--- a/components/charts/Bar.tsx
+++ b/components/charts/Bar.tsx
@@ -1,4 +1,4 @@
-import	React		from	'react';
+import React from 'react';
 import {Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
 import {formatXAxis, formatYAxis} from 'utils/b2b/Chart';
 

--- a/components/charts/Chart.tsx
+++ b/components/charts/Chart.tsx
@@ -1,4 +1,4 @@
-import	React		from	'react';
+import React from 'react';
 import Chevron from '@yearn-finance/web-lib/icons/IconChevron';
 
 import Bar from './Bar';
@@ -26,7 +26,7 @@ function Chart(props: TChartProps): ReactElement {
 
 			<div className={'ml-10 flex w-3/4 items-center justify-center' }>
 				<Chevron className={'cursor-pointer'} onClick={chartNavigation} />
-				<span className={'ml-10 text-neutral-500'}>{'May'}</span> 
+				<span className={'ml-10 text-neutral-500'}>{'May'}</span>
 				<span className={'mx-10 font-semibold'}>{'June'}</span>
 				<span className={'mr-10 text-neutral-500'}>{'July'}</span>
 				<Chevron className={'rotate-180 cursor-pointer'} onClick={chartNavigation} />

--- a/components/charts/ChartLegend.tsx
+++ b/components/charts/ChartLegend.tsx
@@ -1,4 +1,4 @@
-import	React		from	'react';
+import React from 'react';
 
 import type {ReactElement} from 'react';
 import type {TLegendItem} from 'types/chart';
@@ -14,9 +14,9 @@ function MultiItem(props: {details: string[], color: string, isThin?: boolean}):
 			<div>
 				{lines.map((line: string, idx: number): ReactElement => (
 					<p key={`line-${idx}`} className={'ml-2 text-xs underline md:text-sm'}>{line}</p>
-				))} 
+				))}
 			</div>
-		</div> 
+		</div>
 	);
 }
 
@@ -29,7 +29,7 @@ function SingleItem(props: {details: string, color: string, isThin?: boolean}): 
 		<div className={'mb-8 -ml-8 flex flex-row'}>
 			<div className={'h-5 w-4'} style={{width: itemWidth, backgroundColor: props.color}} />
 			<p className={'ml-2 text-xs underline md:text-sm'}>{itemName}</p>
-		</div> 
+		</div>
 	);
 }
 
@@ -40,12 +40,12 @@ function ChartLegend(props: {items: TLegendItem[] }): ReactElement {
 			{props.items.map((item: TLegendItem, idx: number): ReactElement => {
 				const {type, details, color, isThin} = item;
 
-				return (type === 'multi' ? 
+				return (type === 'multi' ?
 					<MultiItem
 						key={idx}
 						color={color}
 						details={details as string[]}
-						isThin={isThin} /> 
+						isThin={isThin} />
 					: <SingleItem
 						key={idx}
 						color={color}

--- a/components/charts/Composed.tsx
+++ b/components/charts/Composed.tsx
@@ -1,11 +1,10 @@
-import	React, {useState}		from	'react';
+import React, {useState} from 'react';
+import CustomTooltip from 'components/charts/CustomTooltip';
 import {Bar, Cell, ComposedChart, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
-
-import {formatXAxis, formatYAxis} from '../../utils/b2b/Chart';
-import CustomTooltip from './CustomTooltip';
+import {formatXAxis, formatYAxis} from 'utils/b2b/Chart';
 
 import type {ReactElement} from 'react';
-import type {TChartProps} from '../../types/chart';
+import type {TChartProps} from 'types/chart';
 
 function	Composed(props: TChartProps): ReactElement {
 	const {tooltipItems, data, bars, windowValue, yAxisOptions, xAxisOptions} = props;
@@ -79,7 +78,7 @@ function	Composed(props: TChartProps): ReactElement {
 					xAxisId={'hidden'}
 					yAxisId={'right'}
 					dataKey={'awb'}
-					fill={bars[1].fill} 
+					fill={bars[1].fill}
 					barSize={getBarSize()} />
 			</ComposedChart>
 		</ResponsiveContainer>

--- a/components/charts/CustomTooltip.tsx
+++ b/components/charts/CustomTooltip.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-import	React		from	'react';
+import React from 'react';
 
 import type {ReactElement} from 'react';
 
@@ -17,9 +16,9 @@ type TTooltipItem = {
 }
 
 function ToolTip(props: TTooltip): ReactElement | null {
-	const {active, items, payload} = props;
+	const {active: isActive, items, payload} = props;
 
-	if (active && payload) {
+	if (isActive && payload) {
 		return (
 			<div className={'rounded bg-good-ol-grey-300 p-2 opacity-90'}>
 				<p>{`Day ${payload[0].payload.name}`}</p>

--- a/components/dashboard/VaultDetails.tsx
+++ b/components/dashboard/VaultDetails.tsx
@@ -1,13 +1,13 @@
-import	React		from	'react';
+import React from 'react';
 import {formatAmount} from '@yearn-finance/web-lib/utils/format.number';
 
 import type {ReactElement} from 'react';
 import type {TPartnerVault} from 'types/types';
 
 
-function	VaultDetails(props: {vault: TPartnerVault}): ReactElement {
+function VaultDetails(props: {vault: TPartnerVault}): ReactElement {
 	const {balance, tvl, apy, riskScore} = props.vault;
-	
+
 	const formatPercent = (n: number, min = 2, max = 2): string => `${formatAmount(n || 0, min, max)}%`;
 
 	return (

--- a/components/dashboard/VaultDetailsTabsWrapper.tsx
+++ b/components/dashboard/VaultDetailsTabsWrapper.tsx
@@ -23,7 +23,15 @@ function	Tabs({selectedIndex, set_selectedIndex}: TProps): ReactElement {
 	return (
 		<>
 			<nav className={'hidden flex-row items-center space-x-10 md:flex'}>
-				{vaults.map((vault, idx): ReactElement => (
+				<button disabled className={'cursor-not-allowed'}>
+					<p
+						title={'Overview'}
+						aria-selected={false}
+						className={'hover-fix tab !cursor-not-allowed'}>
+						{'Overview'}
+					</p>
+				</button>
+				{Object.values(vaults || []).map((vault, idx): ReactElement => (
 					<button
 						key={`desktop-${idx}`}
 						onClick={(): void => set_selectedIndex(idx)}>
@@ -33,7 +41,7 @@ function	Tabs({selectedIndex, set_selectedIndex}: TProps): ReactElement {
 							className={'hover-fix tab'}>
 							{vault.token}
 						</p>
-					</button>	
+					</button>
 				))}
 			</nav>
 			<div className={'relative z-50'}>
@@ -65,7 +73,7 @@ function	Tabs({selectedIndex, set_selectedIndex}: TProps): ReactElement {
 								leaveFrom={'transform scale-100 opacity-100'}
 								leaveTo={'transform scale-95 opacity-0'}>
 								<Listbox.Options className={'yearn--listbox-menu'}>
-									{vaults.map((vault, idx): ReactElement => (
+									{Object.values(vaults || []).map((vault, idx): ReactElement => (
 										<Listbox.Option
 											className={'yearn--listbox-menu-item'}
 											key={idx}
@@ -84,8 +92,8 @@ function	Tabs({selectedIndex, set_selectedIndex}: TProps): ReactElement {
 }
 
 function	VaultDetailsTabsWrapper(): ReactElement {
-	const	{chainID} = useWeb3();
-	const	{vaults} = usePartner();
+	const {chainID} = useWeb3();
+	const {vaults} = usePartner();
 	const [selectedIndex, set_selectedIndex] = useState(0);
 
 	const vaultAddress = vaults[selectedIndex] ? vaults[selectedIndex].address : '';
@@ -96,7 +104,7 @@ function	VaultDetailsTabsWrapper(): ReactElement {
 				<Tabs
 					selectedIndex={selectedIndex}
 					set_selectedIndex={set_selectedIndex} />
-				
+
 				<div className={'flex flex-row items-center justify-end space-x-2 pb-0 md:pb-4 md:last:space-x-4'}>
 					<a
 						href={`${getExplorerURL(chainID)}/address/${vaultAddress}`}
@@ -114,7 +122,7 @@ function	VaultDetailsTabsWrapper(): ReactElement {
 
 			<div className={'-mt-0.5 h-0.5 w-full bg-neutral-300'} />
 
-			{vaults.map((vault, idx): ReactElement | null => {
+			{Object.values(vaults || []).map((vault, idx): ReactElement | null => {
 				return idx === selectedIndex ? <VaultChart vault={vault} key={idx}/> : null;
 			})}
 

--- a/components/graphs/VaultChart.tsx
+++ b/components/graphs/VaultChart.tsx
@@ -9,9 +9,9 @@ import type {TChartData} from 'types/chart';
 import type {TPartnerVault} from 'types/types';
 
 const dataWindows = [
-	{name: '1 week', value: 7}, 
-	{name: '1 month', value: 29}, 
-	{name: '1 year', value: 365}, 
+	{name: '1 week', value: 7},
+	{name: '1 month', value: 29},
+	{name: '1 year', value: 365},
 	{name: 'All time', value: 50}
 ];
 
@@ -33,14 +33,14 @@ function generateData(window = 29): TChartData[]{
 		const revShare = {rsWBTC: ((Math.random()%0.3).toFixed(2)), rsUSDC: ((Math.random()%0.3)).toFixed(2)};
 
 		const baseAggBal = 100 - (Math.random()*50);
-		const aggregateWrapBal = {awb: (baseAggBal * 0.7).toFixed(0), profitShare: baseAggBal.toFixed(0)}; 
-		
+		const aggregateWrapBal = {awb: (baseAggBal * 0.7).toFixed(0), profitShare: baseAggBal.toFixed(0)};
+
 		const baseWrapperBalance = Math.random()*100;
 		const remWrapBalance = 100-baseWrapperBalance;
 		const wrapperBalDist = {rbdWBTC: baseWrapperBalance.toFixed(2), rbdUSDC: remWrapBalance.toFixed(2)};
 
 		data.push({name: `${i+1}`, ...fees, ...revShare, ...aggregateWrapBal, ...wrapperBalDist});
-	} 
+	}
 
 	return data;
 }
@@ -93,7 +93,7 @@ function	VaultChart(props: { vault: TPartnerVault }): ReactElement {
 				xAxisOptions={{interval: getTickInterval()}}
 				tooltipItems={[{name: 'USDC', symbol: 'K'}, {name: 'WBTC', symbol: 'K'}]}
 				legendItems={dummyLegendMulti}/>
-			
+
 			<Chart
 				title={'Revenue Shared'}
 				type={'bar'}

--- a/contexts/usePartner.tsx
+++ b/contexts/usePartner.tsx
@@ -1,95 +1,65 @@
-import	React, {createContext, useContext, useEffect, useMemo, useRef, useState}	from	'react';
-import {NETWORK_LABELS} from 'utils/b2b';
+import	React, {createContext, useContext, useMemo}	from 'react';
+import {useYearn} from 'contexts/useYearn';
+import {NETWORK_CHAINID} from 'utils/b2b';
 import useSWR from 'swr';
-import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
+import {toAddress} from '@yearn-finance/web-lib/utils/address';
 import {baseFetcher} from '@yearn-finance/web-lib/utils/fetchers';
 
-import LogoYearn from '../components/icons/LogoYearn';
-import {LOGOS, PARTNER_SHORT_NAMES} from '../utils/b2b/Partners';
-
-import type {Dispatch, MutableRefObject, ReactElement, SetStateAction} from 'react';
+import type {ReactElement} from 'react';
 import type {SWRResponse} from 'swr';
-import type {TPartnerVault, TPartnerVaultsByNetwork, TYearnVault} from 'types/types';
+import type {TPartnerVault, TPartnerVaultsByNetwork} from 'types/types';
+import type {TDict} from '@yearn-finance/web-lib/utils/types';
 
 type TPartnerContext = {
-	partner: string,
-	logo?: MutableRefObject<ReactElement>,
-	set_partner?: Dispatch<SetStateAction<string>>
-	vaults: TPartnerVault[],
+	vaults: TDict<TPartnerVault>,
 	isLoadingVaults: boolean,
 }
 
 const	defaultProps: TPartnerContext = {
-	partner: '',
-	vaults: [],
+	vaults: {},
 	isLoadingVaults: false
 };
 
 const	Partner = createContext<TPartnerContext>(defaultProps);
 
-export const PartnerContextApp = ({children}: {children: ReactElement}): ReactElement => {
-	const	{chainID} = useWeb3();
-	const	[partner, set_partner] = useState('');
-	const	logo = useRef(<LogoYearn className={'text-900 h-full w-full opacity-0'}/>);
-
-	const isObjectEmpty = (obj: object): boolean => Object.values(obj).length === 0;
-
-	useEffect((): void => {
-		if(partner !== ''){
-			logo.current = LOGOS[partner];
-		}
-	}, [partner]);
-
-	const	{data: yVaults} = useSWR(
-		`${process.env.YDAEMON_BASE_URI}/${chainID}/vaults/all?strategiesDetails=withDetails`,
-		baseFetcher,
-		{revalidateOnFocus: false}
-	) as SWRResponse;
-
-	// Conditonally fetch vault data when partner is set
+export const PartnerContextApp = ({
+	partnerID,
+	children
+}: {partnerID: string, children: ReactElement}): ReactElement => {
+	const	{vaults: yVaults} = useYearn();
 	const	{data: payouts, isLoading: isLoadingVaults} = useSWR(
-		partner ? `${process.env.YVISION_BASE_URI}/partners/${PARTNER_SHORT_NAMES[partner]}/payout_total` : null,
+		`${process.env.YVISION_BASE_URI}/partners/${partnerID}/payout_total`,
 		baseFetcher,
 		{revalidateOnFocus: false}
 	) as SWRResponse;
 
+	const	vaults = useMemo((): TDict<TPartnerVault> => {
+		const vaultsAllNetworksOject = Object.values(payouts || {})[0] as TPartnerVaultsByNetwork;
+		const partnerVaults: TDict<TPartnerVault> = {};
+		for (const [networkName, vaultsForNetwork] of Object.entries(vaultsAllNetworksOject || {})) {
+			const	chainID = NETWORK_CHAINID[networkName];
+			for (const [vaultAddress, currentVault] of Object.entries(vaultsForNetwork || {})) {
+				currentVault.chainID = chainID;
+				currentVault.address = toAddress(vaultAddress);
 
-	const	vaults = useMemo((): TPartnerVault[] => {
-		const currentNetwork = NETWORK_LABELS[chainID];
-
-		const vaultsAllNetworks = Object.values(payouts || {})[0] as TPartnerVaultsByNetwork;
-		const vaultsCurrentNetwork = vaultsAllNetworks ? vaultsAllNetworks[currentNetwork]: {};
-
-		if(!payouts || !yVaults || !vaultsCurrentNetwork || isObjectEmpty(vaultsAllNetworks)){
-			return []; 
-		}
-
-		const _vaults: TPartnerVault[] = [];
-	
-		//Iterate yVaults add relevant details to parter matches
-		yVaults.forEach((yVault: TYearnVault): void => {
-			const partnerVault = vaultsCurrentNetwork[yVault.address];
-
-			if(partnerVault){
-				const {riskScore, apy, address} = yVault;
-
-				const _vault = {...partnerVault, address, riskScore, apy: apy.net_apy};
-
-				if(_vault.balance > 0){
-					_vaults.push(_vault);
+				const	yVaultData = yVaults[currentVault.address];
+				if (yVaultData) {
+					const {riskScore, apy} = yVaultData;
+					currentVault.riskScore = riskScore;
+					currentVault.apy = apy.net_apy;
+					if (currentVault.balance > 0) {
+						partnerVaults[`${currentVault.address}_${chainID}`] = currentVault;
+					}
 				}
 			}
-		});
-		
-		return _vaults;
-	}, [chainID, payouts, yVaults]);
+		}
+
+		return partnerVaults;
+	}, [payouts, yVaults]);
 
 	return (
 		<Partner.Provider
 			value={{
-				partner,
-				set_partner,
-				logo,
 				vaults: vaults,
 				isLoadingVaults
 			}}>

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -1,0 +1,59 @@
+import React, {createContext, memo, useContext, useMemo} from 'react';
+import useSWR from 'swr';
+import {useSettings} from '@yearn-finance/web-lib/contexts/useSettings';
+import {toAddress} from '@yearn-finance/web-lib/utils/address';
+import {baseFetcher} from '@yearn-finance/web-lib/utils/fetchers';
+
+import type {ReactElement} from 'react';
+import type {SWRResponse} from 'swr';
+import type {TYearnVault} from 'types/types';
+import type {TDict, VoidPromiseFunction} from '@yearn-finance/web-lib/utils/types';
+
+export type	TYearnContext = {
+	vaults: TDict<TYearnVault>,
+	isLoadingVaultList: boolean,
+	mutateVaultList: VoidPromiseFunction
+}
+const	defaultProps: TYearnContext = {
+	vaults: {},
+	isLoadingVaultList: false,
+	mutateVaultList: async (): Promise<void> => Promise.resolve()
+};
+
+const	YearnContext = createContext<TYearnContext>(defaultProps);
+export const YearnContextApp = memo(function YearnContextApp({children}: {children: ReactElement}): ReactElement {
+	const {settings: baseAPISettings} = useSettings();
+
+	const	{data: vaults, isLoading: isLoadingVaultList, mutate: mutateVaultList} = useSWR(
+		`${baseAPISettings.yDaemonBaseURI}/vaults/all?strategiesDetails=withDetails`,
+		baseFetcher,
+		{revalidateOnFocus: false}
+	) as SWRResponse;
+
+
+	const	vaultsObject = useMemo((): TDict<TYearnVault> => {
+		const	_vaultsObject = (vaults || []).reduce((acc: TDict<TYearnVault>, vault: TYearnVault): TDict<TYearnVault> => {
+			acc[toAddress(vault.address)] = vault;
+			return acc;
+		}, {});
+		return _vaultsObject;
+	}, [vaults]);
+
+	/* 🔵 - Yearn Finance ******************************************************
+	**	Setup and render the Context provider to use in the app.
+	***************************************************************************/
+	const	contextValue = useMemo((): TYearnContext => ({
+		vaults: vaultsObject,
+		isLoadingVaultList,
+		mutateVaultList
+	}), [vaultsObject, isLoadingVaultList, mutateVaultList]);
+
+	return (
+		<YearnContext.Provider value={contextValue}>
+			{children}
+		</YearnContext.Provider>
+	);
+});
+
+export const useYearn = (): TYearnContext => useContext(YearnContext);
+export default useYearn;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,40 +1,22 @@
-/* eslint-disable jsx-a11y/role-supports-aria-props */
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import {useRouter} from 'next/router';
 import {SessionProvider, useSession} from 'next-auth/react';
 import {DefaultSeo} from 'next-seo';
-import {PartnerContextApp} from 'contexts/usePartner';
+import {YearnContextApp} from 'contexts/useYearn';
 import {Button} from '@yearn-finance/web-lib/components/Button';
-import {Dropdown} from '@yearn-finance/web-lib/components/Dropdown';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 import {WithYearn} from '@yearn-finance/web-lib/contexts/WithYearn';
 import {useClientEffect} from '@yearn-finance/web-lib/hooks';
-import NetworkArbitrum from '@yearn-finance/web-lib/icons/IconNetworkArbitrum';
-import NetworkEthereum from '@yearn-finance/web-lib/icons/IconNetworkEthereum';
-import NetworkFantom from '@yearn-finance/web-lib/icons/IconNetworkFantom';
-import NetworkOptimism from '@yearn-finance/web-lib/icons/IconNetworkOptimism';
+import {truncateHex} from '@yearn-finance/web-lib/utils/address';
 
 import type {AppProps} from 'next/app';
 import type {ReactElement} from 'react';
 
 import '../style.css';
 
-type TNetworkOption = {
-	icon: ReactElement,
-	label: string,
-	value: number
-}
-
-const	options: TNetworkOption[] = [
-	{icon: <NetworkEthereum />, label: 'Ethereum', value: 1},
-	{icon: <NetworkFantom />, label: 'Fantom', value: 250},
-	{icon: <NetworkOptimism />, label: 'Optimism', value: 10},
-	{icon: <NetworkArbitrum />, label: 'Arbitrum', value: 42161}
-];
-
-function	AppHead(): ReactElement {	
+function	AppHead(): ReactElement {
 	return (
 		<>
 			<Head>
@@ -109,16 +91,9 @@ function	AppHead(): ReactElement {
 
 function	AppHeader(): ReactElement {
 	const	router = useRouter();
-	const	{chainID, isActive, address, openLoginModal, onSwitchChain} = useWeb3();
+	const	{isActive, address, ens, openLoginModal, onSwitchChain, onDesactivate} = useWeb3();
 	const	{data: session} = useSession();
-	const	[walletIdentity] = useState('Log in');
-
-	const	[selectedOption, set_selectedOption] = useState(options[0]);
-
-	useEffect((): void => {
-		const	_selectedOption = options.find((e): boolean => e.value === Number(chainID)) || options[0];
-		set_selectedOption(_selectedOption);
-	}, [chainID, isActive]);
+	const	[walletIdentity, set_walletIdentity] = useState('Log in');
 
 	// const	hasPendingSignature = useRef(false);
 
@@ -142,20 +117,13 @@ function	AppHeader(): ReactElement {
 
 	// }, [provider, address, router]);
 
-	// useClientEffect((): void => {
-	// 	if (!isActive && address) {
-	// 		set_walletIdentity('Switch network');
-	// 	} else if (address) {
-	// 		console.log(session);
-	// 		if (!session) {
-	// 			authenticate(ens);
-	// 		} else if (session) {
-	// 			set_walletIdentity(ens ? ens : truncateHex(address, 4));
-	// 		}
-	// 	} else {
-	// 		set_walletIdentity('Log in');
-	// 	}
-	// }, [ens, address, isActive, session, authenticate]);
+	useClientEffect((): void => {
+		if (address) {
+			set_walletIdentity(ens ? ens : truncateHex(address, 6));
+		} else {
+			set_walletIdentity('Log in');
+		}
+	}, [ens, address, isActive, session]);
 
 	useClientEffect((): void => {
 		if (session) {
@@ -166,7 +134,7 @@ function	AppHeader(): ReactElement {
 
 	async function	onLogIn(): Promise<void> {
 		if (isActive) {
-			// await onDesactivate();
+			await onDesactivate();
 			// if (session) {
 			// 	await signOut({redirect: false});
 			// }
@@ -180,44 +148,37 @@ function	AppHeader(): ReactElement {
 	return (
 		<header>
 			<div className={'flex w-full flex-row items-center justify-between py-6'}>
-				<div className={'flex flex-row items-center space-x-6 md:space-x-10'}>
+				<nav className={'flex flex-row items-center space-x-6 md:space-x-10'}>
 					<div>
 						<Link href={'/'}>
-							<nav
+							<p
 								aria-selected={router.pathname === '/'}
 								className={'project--nav'}>
 								{'Main'}
-							</nav>
+							</p>
 						</Link>
 					</div>
 					<div>
 						<Link href={'/'}>
-							<nav
+							<p
 								aria-selected={router.pathname === '/team-up'}
 								className={'project--nav'}>
 								{'Team up'}
-							</nav>
+							</p>
 						</Link>
 					</div>
 					<div>
-						<Link href={'/dashboard'}>
-							<nav
+						<Link href={'/'}>
+							<p
 								aria-selected={router.pathname === '/learn-more'}
 								className={'project--nav'}>
 								{'Learn more'}
-							</nav>
+							</p>
 						</Link>
 					</div>
-				</div>
+				</nav>
 
 				<div className={'flex flex-row items-center space-x-6 md:space-x-10'}>
-					<Dropdown
-						defaultOption={options[0]}
-						options={options}
-						selected={selectedOption}
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						onSelect={(option: any): void => onSwitchChain(option.value as number, true)} />
-
 					<Button
 						variant={'filled'}
 						className={'!h-[30px]'}
@@ -264,14 +225,14 @@ function	MyApp(props: AppProps): ReactElement {
 					supportedChainID: [1, 250, 42161, 1337, 31337]
 				}
 			}}>
-			<PartnerContextApp>
+			<YearnContextApp>
 				<SessionProvider /*session={pageProps.session} */ >
 					<AppWrapper
 						Component={Component}
 						pageProps={pageProps}
 						router={props.router} />
 				</SessionProvider>
-			</PartnerContextApp>
+			</YearnContextApp>
 		</WithYearn>
 	);
 }

--- a/pages/disclaimer.tsx
+++ b/pages/disclaimer.tsx
@@ -1,7 +1,7 @@
-import	React	from	'react';
-import	Link					from	'next/link';
-import	{Card}					from	'@yearn-finance/web-lib/components/Card';
-import	Cross					from	'@yearn-finance/web-lib/icons/IconCross';
+import React from 'react';
+import Link from 'next/link';
+import {Card} from '@yearn-finance/web-lib/components/Card';
+import Cross from '@yearn-finance/web-lib/icons/IconCross';
 
 import type {ReactElement} from 'react';
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,8 @@
-import	React	from	'react';
-import	B2BMeme					from	'components/B2BMeme';
-import	SectionPartner			from	'components/SectionPartners';
-import	SectionStats			from	'components/SectionStats';
-import	SectionTargets			from	'components/SectionTargets';
+import React from 'react';
+import B2BMeme from 'components/B2BMeme';
+import SectionPartner from 'components/SectionPartners';
+import SectionStats from 'components/SectionStats';
+import SectionTargets from 'components/SectionTargets';
 import {Button} from '@yearn-finance/web-lib/components/Button';
 
 import type {ReactElement} from 'react';
@@ -28,7 +28,7 @@ function	Index(): ReactElement {
 					<B2BMeme />
 				</div>
 			</section>
-		
+
 			<SectionStats />
 
 			<SectionTargets />

--- a/types/types.tsx
+++ b/types/types.tsx
@@ -1,5 +1,6 @@
 import type	{ReactElement}	from	'react';
 import type {TAddress} from '@yearn-finance/web-lib/utils/address';
+import type {TDict} from '@yearn-finance/web-lib/utils/types';
 
 export type TPartnerVault = {
 	address: string,
@@ -10,18 +11,16 @@ export type TPartnerVault = {
 	network: string
 	riskScore: number,
 	apy: number
+	chainID: number
 };
 
-type TPartnerVaultByAddress = {
-	[address: string]: TPartnerVault
-}
-
 export type TPartnerVaultsByNetwork = {
-	[network: string]: TPartnerVaultByAddress
+	[network: string]: TDict<TPartnerVault>
 }
 
 export type TPartnerList = {
 	name: string;
+	shortName: string;
 	description: string;
 	logo: ReactElement;
 }
@@ -88,6 +87,7 @@ export type TYearnVault = {
 	icon: string,
 	category: string,
 	riskScore: number,
+	chainID: number,
 	token: {
 		address: TAddress,
 		name: string,

--- a/utils/b2b/Partners.tsx
+++ b/utils/b2b/Partners.tsx
@@ -14,38 +14,47 @@ import	type {TPartnerList}		from	'types/types';
 const	PARTNERS: TPartnerList[] = [
 	{
 		name: 'QiDAO',
+		shortName: 'qidao',
 		description: 'A stablecoin protocol utilizing collateralized debt positions',
 		logo: <LogoQiDAO className={'text-900'} />
 	}, {
 		name: 'Element Finance',
+		shortName: 'element',
 		description: 'An open source protocl for fixed and variable yield markets',
 		logo: <LogoElement className={'text-900'} />
 	}, {
 		name: 'Brave',
+		shortName: 'brave',
 		description: 'Fast, private, secure web browser for PC, Mac, and mobile',
 		logo: <LogoBrave className={'text-900'} />
 	}, {
 		name: 'Abracadabra',
+		shortName: 'abracadabra',
 		description: 'A decentralized crypto lending platform ',
 		logo: <LogoMIM className={'text-900'} />
 	}, {
 		name: 'Ledger',
+		shortName: 'ledger',
 		description: 'An application to quickly and securely manage their assets',
 		logo: <LogoLedger className={'text-900'} />
 	}, {
 		name: 'Alchemix',
+		shortName: 'alchemix',
 		description: 'Self-repaying loans without risk of liquidation',
 		logo: <LogoAlchemix className={'text-900'} />
 	}, {
 		name: 'Gearbox',
+		shortName: 'gearbox',
 		description: 'A generalized leverage protocol',
 		logo: <LogoGearbox className={'text-900'} />
 	}, {
 		name: 'Inverse Finance',
+		shortName: 'inverse',
 		description: 'An open source protocol for borrowing and lending assets',
 		logo: <LogoInverse className={'text-900'} />
 	}, {
 		name: 'ZooDAO',
+		shortName: 'zoodao',
 		description: 'A platform that allows users to earn passive income from NFTs',
 		logo: <LogoZooDao className={'text-900'} />
 	}
@@ -61,7 +70,7 @@ const PARTNER_SHORT_NAMES: {[key: string]: string} = {
 	'Alchemix': 'alchemix',
 	'Gearbox': 'gearbox',
 	'Inverse Finance': 'inverse',
-	'ZooDAO': 'zoodao' //* 
+	'ZooDAO': 'zoodao' //*
 };
 
 type TPartnerLogo = {

--- a/utils/b2b/index.tsx
+++ b/utils/b2b/index.tsx
@@ -1,21 +1,28 @@
 export const NETWORK_LABELS: { [key: number]: string } = {
 	1: 'ETH',
-	250: 'FTM',
 	10: 'OPT',
+	250: 'FTM',
 	42161: 'ARRB'
+};
+
+export const NETWORK_CHAINID: { [key: string]: number } = {
+	'ETH': 1,
+	'OPT': 10,
+	'FTM': 250,
+	'ARRB': 42161
 };
 
 export function getExplorerURL(chainID: number): string {
 	switch (chainID) {
-	case 1:
-		return 'https://etherscan.io';
-	case 250:
-		return 'https://ftmscan.com';
-	case 10:
-		return 'https://optimistic.etherscan.io';
-	case 42161:
-		return 'https://arbiscan.io';
-	default:
-		return ('https://etherscan.io');
+		case 1:
+			return 'https://etherscan.io';
+		case 250:
+			return 'https://ftmscan.com';
+		case 10:
+			return 'https://optimistic.etherscan.io';
+		case 42161:
+			return 'https://arbiscan.io';
+		default:
+			return ('https://etherscan.io');
 	}
 }


### PR DESCRIPTION
- Split the contexts in `useYearn` and `usePartner`
- Use the `getStaticPaths`, `getStaticProps` and specific `[something].tsx` routes API to dynamically create one page per partner
- Move the `usePartner` context to the partner dashboard
- Remove the whole app network selector and merge multiple networks in one view. Design in progress by Evan