### PR TITLE
refactor: Apply media queries

### DIFF
--- a/components/dashboard/SummaryMetrics.tsx
+++ b/components/dashboard/SummaryMetrics.tsx
@@ -23,25 +23,54 @@ function SummaryMetrics(props: TProps): ReactElement {
 	const allVaultsFees = Object.values(vaults).reduce(((acc, vault): number => acc + vault.totalPayout), 0);
 	
 	return (
-		<div className={'my-20 flex w-[80%] justify-between bg-good-ol-grey-100'}>
-			<div>
-				<p>{'TVL'}</p>
-				<h1>{'$ '}{vault ? formatAmount(props.vault.tvl) : formatAmount(allVaultsTVL)}</h1>
+		<div>
+			<div className={'my-20 hidden w-[80%] justify-between bg-good-ol-grey-100 md:flex'}>
+				<div>
+					<p>{'TVL'}</p>
+					<h1>{'$ '}{vault ? formatAmount(props.vault.tvl) : formatAmount(allVaultsTVL)}</h1>
+				</div>
+
+				<div>
+					<p>{'Fees earned to date'}</p>
+					<h1>{'$ '}{vault ? formatAmount(props.vault.totalPayout, 0, 2) : formatAmount(allVaultsFees)}</h1>
+				</div>
+
+				<div>
+					<p>{'Annual Yield'}</p>
+					<h1>{vault ? formatPercent(props.vault.apy) : '-'}</h1>
+				</div>
+
+				<div>
+					<p>{'Risk Score'}</p>
+					<h1>{vault ? formatAmount(props.vault.riskScore, 0, 2) : '-'}</h1>
+				</div>
 			</div>
 
-			<div>
-				<p>{'Fees earned to date'}</p>
-				<h1>{'$ '}{vault ? formatAmount(props.vault.totalPayout, 0, 2) : formatAmount(allVaultsFees)}</h1>
-			</div>
+			<div className={'my-20 flex w-[60%] justify-between bg-good-ol-grey-100 md:hidden'}>
+				<div>
+					<div className={'mb-5'}>
+						<p>{'TVL'}</p>
+						<h1>{'$ '}{vault ? formatAmount(props.vault.tvl) : formatAmount(allVaultsTVL)}</h1>
+					</div>
 
-			<div>
-				<p>{'Annual Yield'}</p>
-				<h1>{vault ? formatPercent(props.vault.apy) : '-'}</h1>
-			</div>
+					<div>
+						<p>{'Fees earned to date **'}</p>
+						<h1>{'$ '}{vault ? formatAmount(props.vault.balance, 0, 2) : formatAmount(allVaultsFees)}</h1>
+					</div>
+				</div>
 
-			<div>
-				<p>{'Risk Score'}</p>
-				<h1>{vault ? formatAmount(props.vault.riskScore, 0, 2) : '-'}</h1>
+				<div>
+					<div className={'mb-5'}>
+						<p>{'Annual Yield'}</p>
+						<h1>{vault ? formatPercent(props.vault.apy) : '-'}</h1>
+					</div>
+
+					<div>
+						<p>{'Risk Score'}</p>
+						<h1>{vault ? formatAmount(props.vault.riskScore, 0, 2) : '-'}</h1>
+					</div>
+				</div>
+
 			</div>
 		</div>
 	);

--- a/components/dashboard/SummaryMetrics.tsx
+++ b/components/dashboard/SummaryMetrics.tsx
@@ -54,7 +54,7 @@ function SummaryMetrics(props: TProps): ReactElement {
 					</div>
 
 					<div>
-						<p>{'Fees earned to date **'}</p>
+						<p>{'Fees earned to date'}</p>
 						<h1>{'$ '}{vault ? formatAmount(props.vault.balance, 0, 2) : formatAmount(allVaultsFees)}</h1>
 					</div>
 				</div>


### PR DESCRIPTION
## Description

The values in the `SummaryMetrics` component of each dashboard are very close together when the available screen size decreases. To address this I applied media queries to improve appearance and ensure the legibility of values on different screen sizes.

## Motivation and Context

The intention after applying media queries is to improve the appearance of this section. Currently no responsive styles are applied to the SummaryMetrics section leading to overlap and difficulty when viewing on small screens.

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed that everything appeared as expected

## Screenshots (if appropriate):

N/A