### PR TITLE
chore: Add Issue / PR Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug Report
+about: Create a report to help us improve the dapp
+title: 'Bug: '
+labels: bug 
+---
+
+### What happened 🆘
+**A clear and concise description of what the bug is.**
+
+### To Reproduce 🔂
+Steps to reproduce the behavior:
+
+### More 🔎
+- Browser : 
+
+## Screenshots
+**If applicable, add screenshots to help explain your problem.**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature Request Proposal
+about: Ask for a new feature for this website
+title: 'FRP: ' 
+---
+
+### What is your proposal 🚀
+**A clear and concise description of what you are asking for.**
+
+### What does this solve ? 🛠
+**A clear and concise description about why this is a nice to have.**
+
+### More 🔎
+*N/A*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Description
+
+<!--- Describe your changes -->
+
+## Related Issue
+
+<!--- Please link to the issue here -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+
+<!--- Please describe in detail how you tested your changes. -->
+
+## Resources
+
+<!--- Any screenshots (if appropriate), links or relevant resources to explain better the changes. -->


### PR DESCRIPTION
## Description

This pull request creates a new ISSUE_TEMPLATES folder with the files: `bug reports` and `feature request` and adds the `pull request` template to the .github folder. Their purpose is essentially guiding and facilitating the contribution process in the repo. Its content matches that found in the main `yearn.fi` repo for further standardization.

## Motivation and Context

The motivation is that these templates can be helpful to standardize and organize the most relevant information of the request. This way of organizing details also leaves the information easy to review by contributors.

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

N/A