### PR TITLE
Switch Envio auth from Basic to Bearer JWT

### DIFF
--- a/pages/api/partner-fees.ts
+++ b/pages/api/partner-fees.ts
@@ -171,11 +171,16 @@ async function queryEnvioGraphQL<T>(query: string, variables: Record<string, unk
 
 	const payload = JSON.stringify({query, variables});
 
+	const headers: Record<string, string> = {
+		'Content-Type': 'application/json'
+	};
+	if (process.env.ENVIO_PASSWORD) {
+		headers['Authorization'] = `Bearer ${process.env.ENVIO_PASSWORD}`;
+	}
+
 	const response = await fetch(envioUrl, {
 		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json'
-		},
+		headers,
 		body: payload
 	});
 

--- a/pages/api/partner-referrals.ts
+++ b/pages/api/partner-referrals.ts
@@ -41,11 +41,16 @@ async function queryEnvioGraphQL<T>(query: string, variables: Record<string, unk
 
 	const payload = JSON.stringify({query, variables});
 
+	const headers: Record<string, string> = {
+		'Content-Type': 'application/json'
+	};
+	if (process.env.ENVIO_PASSWORD) {
+		headers['Authorization'] = `Bearer ${process.env.ENVIO_PASSWORD}`;
+	}
+
 	const response = await fetch(envioUrl, {
 		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json'
-		},
+		headers,
 		body: payload
 	});
 

--- a/scripts/calc_depositor_fees.py
+++ b/scripts/calc_depositor_fees.py
@@ -2,7 +2,6 @@
 """Python port of the Yearn V3 depositor fee calculator."""
 
 import argparse
-import base64
 import bisect
 import datetime
 import json
@@ -63,7 +62,7 @@ DOTENV_FILE = os.path.join(os.getcwd(), '.env')
 load_local_env(DOTENV_FILE)
 
 ENVIO_GRAPHQL_URL = os.environ.get('ENVIO_GRAPHQL_URL')
-ENVIO_PASSWORD = os.environ.get('ENVIO_PASSWORD', 'testing')
+ENVIO_TOKEN = os.environ.get('ENVIO_PASSWORD', '')
 DEFAULT_VAULT_ADDRESS = '0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204'
 DEFAULT_CHAIN_ID = 1
 CHAIN_CONFIG = {
@@ -450,10 +449,9 @@ def format_units_display(value: int, decimals: int) -> str:
 
 def query_envio_graphql(query: str, variables: Dict[str, Any]) -> Dict[str, Any]:
     payload = json.dumps({'query': query, 'variables': variables}).encode('utf-8')
-    auth = base64.b64encode(f":{ENVIO_PASSWORD}".encode('utf-8')).decode('utf-8')
     headers = {
         'Content-Type': 'application/json',
-        'Authorization': f'Basic {auth}',
+        'Authorization': f'Bearer {ENVIO_TOKEN}',
     }
     request = urllib.request.Request(ENVIO_GRAPHQL_URL, data=payload, headers=headers)
     try:


### PR DESCRIPTION
## Summary
- Replace base64-encoded Basic auth with Bearer token auth for all Envio GraphQL requests
- `ENVIO_PASSWORD` env var now holds a JWT token instead of a password
- Remove unused `base64` import from Python script
- Add `Authorization: Bearer` header to TypeScript API routes (`partner-fees.ts`, `partner-referrals.ts`)

## Test plan

- [ ] Set `ENVIO_PASSWORD` to a valid JWT token in `.env`
- [ ] Run the Python fee calculator and verify GraphQL queries succeed
```
python scripts/calc_depositor_fees.py --vault 0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204 --chain 1
```
- [ ] Hit the partner-fees and partner-referrals API endpoints and verify they return data
```
curl -s http://localhost:3000/api/partner-fees | head -c 200
curl -s http://localhost:3000/api/partner-referrals | head -c 200
```
Expected: valid JSON responses (not 401/403 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)