### PR TITLE
Fix Turnstile widget disappearing on client-side navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	},
 	"dependencies": {
 		"@headlessui/react": "2.2.10",
+		"@marsidev/react-turnstile": "1.5.4",
 		"axios": "1.16.0",
 		"ethers": "5.8.0",
 		"framer-motion": "12.38.0",

--- a/pages/team-up.tsx
+++ b/pages/team-up.tsx
@@ -1,7 +1,8 @@
 import axios from 'axios';
-import Script from 'next/script';
+import {Turnstile} from '@marsidev/react-turnstile';
 import {useCallback, useRef, useState} from 'react';
 
+import type {TurnstileInstance} from '@marsidev/react-turnstile';
 import type {FormEvent, ReactElement} from 'react';
 
 type TFormResponse = {
@@ -15,13 +16,11 @@ function	TeamUpPage(): ReactElement {
 	const [response, setResponse] = useState<TFormResponse | null>(null);
 	const [turnstileToken, setTurnstileToken] = useState('');
 	const formRef = useRef<HTMLFormElement>(null);
-	const turnstileRef = useRef<HTMLDivElement>(null);
+	const turnstileRef = useRef<TurnstileInstance | undefined>(undefined);
 
 	const resetTurnstile = useCallback((): void => {
 		setTurnstileToken('');
-		if (window.turnstile && turnstileRef.current) {
-			window.turnstile.reset(turnstileRef.current);
-		}
+		turnstileRef.current?.reset();
 	}, []);
 
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
@@ -156,12 +155,13 @@ function	TeamUpPage(): ReactElement {
 						</div>
 						{process.env.CLOUDFLARE_TURNSTILE_SITE_KEY ? (
 							<div className={'md:col-span-2'}>
-								<div
+								<Turnstile
 									ref={turnstileRef}
-									className={'cf-turnstile'}
-									data-callback={'onTurnstileCallback'}
-									data-sitekey={process.env.CLOUDFLARE_TURNSTILE_SITE_KEY}
-									data-theme={'light'} />
+									siteKey={process.env.CLOUDFLARE_TURNSTILE_SITE_KEY}
+									options={{theme: 'light'}}
+									onSuccess={(token): void => setTurnstileToken(token)}
+									onExpire={(): void => setTurnstileToken('')}
+									onError={(): void => setTurnstileToken('')} />
 							</div>
 						) : null}
 						<div className={'md:col-span-2'}>
@@ -180,25 +180,8 @@ function	TeamUpPage(): ReactElement {
 				</div>
 			</div>
 
-			{process.env.CLOUDFLARE_TURNSTILE_SITE_KEY ? (
-				<Script
-					src={'https://challenges.cloudflare.com/turnstile/v0/api.js'}
-					strategy={'afterInteractive'}
-					onReady={(): void => {
-						(window as Window).onTurnstileCallback = (token: string): void => {
-							setTurnstileToken(token);
-						};
-					}} />
-			) : null}
 		</div>
 	);
-}
-
-declare global {
-	interface Window {
-		turnstile?: {reset: (element: HTMLElement) => void};
-		onTurnstileCallback?: (token: string) => void;
-	}
 }
 
 export default TeamUpPage;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@headlessui/react':
         specifier: 2.2.10
         version: 2.2.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@marsidev/react-turnstile':
+        specifier: 1.5.4
+        version: 1.5.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       axios:
         specifier: 1.16.0
         version: 1.16.0(debug@4.4.3(supports-color@8.1.1))
@@ -557,6 +560,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@marsidev/react-turnstile@1.5.4':
+    resolution: {integrity: sha512-2+ulBzQPYcC5jZ4Pghlcc6a6+CQ6L0cgTxtbavZbcHcG5/wSQsTAM+vDudF94L9AUPG4uSNQF1kotmvx0Ns/QA==}
+    peerDependencies:
+      react: ^17.0.2 || ^18.0.0 || ^19.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3613,6 +3622,11 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@marsidev/react-turnstile@1.5.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:


### PR DESCRIPTION
### Summary

The contact form's CAPTCHA silently stopped rendering when you reached `/team-up` by clicking through the app rather than loading it directly, making the form impossible to submit — it rejected itself with "Please complete the verification challenge" while showing no challenge to complete.

**Steps to reproduce (on production today):**
- Home, click **Apply** → captcha shows
- Click **Main** (top left)
- Click **Apply** → captcha gone

The cause is Cloudflare Turnstile's *implicit* rendering (`class="cf-turnstile"` + a bare `api.js`), which scans the DOM exactly once when the script first executes and never again. `next/script` won't re-run an already-loaded script, so the second and subsequent visits to `/team-up` within one document session get an empty container. Replaced with `@marsidev/react-turnstile`, which renders explicitly via Cloudflare's `onload` handshake and ties widget create/reset/remove to the React lifecycle.

This is the client-side counterpart to the recent server-side enforcement hardening — that closed the bypass for attackers POSTing without a token; this restores the widget for legitimate users who never got one.

### How to review

Start with `pages/team-up.tsx` — it's the only behavioral change, and it's a net deletion. The `Turnstile` component replaces the container div, the `Script` tag, and all the widget-ID bookkeeping. `package.json` / `pnpm-lock.yaml` are just the pinned dependency.

Dependency vetting (size, license, Socket scores, the single-maintainer flag, and why 1.5.4 rather than 1.5.5) is recorded in the commit body.

### Test plan

- [ ] Manual — **the regression itself**: home → click **Apply** (captcha shows) → click **Main** → click **Apply**. Captcha must still show on the second visit. This is the sequence that fails on `main` today.
- [ ] Manual — hard-load `/team-up` directly; widget renders, form submits end to end.
- [ ] Manual — leave the form open >5 min, then submit; token expiry should re-challenge rather than 403.
- [x] Automated — `tsc --noEmit`, `eslint`, `next build` (with and without the site key), `vitest run tests/telegram.test.ts` (5/5)

### Risk / impact

Touches spam protection on the public contact form, so a regression here means either blocked legitimate users or a reopened spam vector. Mitigating factors: server-side verification in `/api/telegram` is unchanged, so the enforcement path is untouched; and the whole widget stays behind the existing `CLOUDFLARE_TURNSTILE_SITE_KEY` guard. Rollback is reverting one commit — no migration, no state.

Not verified in a real browser by me — every manual box above is genuinely unchecked. I'd want the first item confirmed on a preview deploy before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
